### PR TITLE
Update install-prerequisites.ipynb

### DIFF
--- a/content/modules/ROOT/assets/notebooks/install-prerequisites.ipynb
+++ b/content/modules/ROOT/assets/notebooks/install-prerequisites.ipynb
@@ -202,6 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%bash\n",
     "oc create rolebinding python-edit --clusterrole=edit --serviceaccount=$(oc project -q):$(oc whoami)-workbench\n",
     "oc create role python-edit-rolebindings --verb=get,list,watch,create,update,patch,delete --resource=roles,rolebindings\n",
     "oc create rolebinding python-edit-rolebindings --role=python-edit-rolebindings --serviceaccount=$(oc project -q):$(oc whoami)-workbench"


### PR DESCRIPTION
bash is missing for oc commands